### PR TITLE
Fix Railway CLI authentication - remove unsupported --token flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           CI: true
         run: |
-          npx @railway/cli login --token ${{ secrets.RAILWAY_TOKEN }}
           npx @railway/cli link --project 2eb61cd2-5948-48ed-bc2d-bd7b6b37367c --environment production
           npx @railway/cli up --detach
 


### PR DESCRIPTION
## Summary
- Remove unsupported --token flag from Railway CLI login command
- Railway CLI authenticates automatically using RAILWAY_TOKEN environment variable
- Fixes deployment error: 'unexpected argument --token found'

## Changes
- Removed `npx @railway/cli login --token` command from CI deployment step
- CLI will use RAILWAY_TOKEN env var for authentication automatically

🤖 Generated with [Claude Code](https://claude.ai/code)