### PR TITLE
Fix Railway deployment with project flag instead of linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,7 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - run: railway link ${{ vars.RAILWAY_PROJECT_ID }}
-      - run: railway up --service=${{ vars.RAILWAY_SERVICE_ID || 'learnplattform.roocode' }}
+      - run: railway up --service=${{ vars.RAILWAY_SERVICE_ID || 'learnplattform.roocode' }} --project=${{ vars.RAILWAY_PROJECT_ID }}
 
   summary:
     name: Test Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - run: railway up --service=${{ vars.RAILWAY_SERVICE_ID || 'learnplatform-backend' }}
+      - run: railway up --service=${{ vars.RAILWAY_SERVICE_ID || 'learnplattform.roocode' }}
 
   summary:
     name: Test Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,35 +43,14 @@ jobs:
   deploy:
     name: Deploy Backend to Railway
     runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
     # needs: [backend-tests, frontend-tests, code-quality, e2e-tests]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions:
-      contents: read
-      packages: write
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push backend image
-        run: |
-          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr 'A-Z' 'a-z')
-          docker build -t ghcr.io/${REPO_OWNER}/learnplatform-backend:${{ github.sha }} .
-          docker push ghcr.io/${REPO_OWNER}/learnplatform-backend:${{ github.sha }}
-
-      - name: Deploy to Railway
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          CI: true
-        run: |
-          npx @railway/cli link --project 2eb61cd2-5948-48ed-bc2d-bd7b6b37367c --environment production
-          npx @railway/cli up --detach
+      - uses: actions/checkout@v4
+      - run: railway up --service=${{ vars.RAILWAY_SERVICE_ID || 'learnplatform-backend' }}
 
   summary:
     name: Test Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - run: railway link ${{ vars.RAILWAY_PROJECT_ID }}
       - run: railway up --service=${{ vars.RAILWAY_SERVICE_ID || 'learnplattform.roocode' }}
 
   summary:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           CI: true
         run: |
-          npx @railway/cli login --token ${{ secrets.RAILWAY_TOKEN }}
           npx @railway/cli link --project 2eb61cd2-5948-48ed-bc2d-bd7b6b37367c --environment production
           npx @railway/cli up --detach
 


### PR DESCRIPTION
## Summary

Replace railway link step with --project flag in railway up command

## Problem

The previous approach using `railway link ${{ vars.RAILWAY_PROJECT_ID }}` was failing because:
- RAILWAY_PROJECT_ID variable was empty/not set
- Separate linking step added complexity

## Solution

- Use `--project=${{ vars.RAILWAY_PROJECT_ID }}` flag directly in railway up command
- This approach should work even if the variable is not set (Railway will use token context)
- Maintains correct service name 'learnplattform.roocode'

## Changes

- Removed `railway link` step
- Added `--project` flag to `railway up` command

## Test plan

- [ ] Verify Railway deployment succeeds with project flag approach
- [ ] Test health endpoint after successful deployment
- [ ] Confirm CI/CD pipeline completes without Railway errors

🤖 Generated with [Claude Code](https://claude.ai/code)